### PR TITLE
Add ability to enable metrics in Grafana

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,10 +95,49 @@ jobs:
         run: ansible-test integration -v delete_cloud_stack --color --retry-on-error --continue-on-error --diff --python ${{ matrix.python }} --coverage --docker
         working-directory: ./ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
 
+  publish:
+    name: Publish to Galaxy
+    runs-on: ubuntu-latest
+    needs: [sanity, integration]
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+
+      - name: Install Ansible
+        run: pip install ansible-core
+      
+      - name: Install PyYaml
+        run: pip install pyyaml
+
+      - name: Validate version matches
+        run: |
+          VERSION=$(python -c "import yaml; print(yaml.safe_load(open('galaxy.yml'))['version'])")
+          if [ "$VERSION" != "${{ github.event.inputs.version }}" ]; then
+            echo "Error: Input version (${{ github.event.inputs.version }}) doesn't match galaxy.yml version ($VERSION)"
+            exit 1
+          fi
+
+      - name: Build collection
+        id: build
+        run: |
+          ansible-galaxy collection build
+          echo "archive_path=$(ls *.tar.gz)" >> $GITHUB_OUTPUT
+
+      - name: Publish collection to Galaxy
+        env:
+          ANSIBLE_GALAXY_API_KEY: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}
+        run: ansible-galaxy collection publish --api-key ${{ secrets.ANSIBLE_GALAXY_API_KEY }} ${{ steps.build.outputs.archive_path }}
+
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [sanity, integration]
+    needs: [publish]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/roles/grafana/README.md
+++ b/roles/grafana/README.md
@@ -52,6 +52,12 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `grafana_environment` | {} | Optional Environment param for Grafana installation, useful ie for setting http_proxy |
 | `grafana_plugins` | [] |  List of Grafana plugins which should be installed |
 | `grafana_alert_notifications` | [] | List of alert notification channels to be created, updated, or deleted |
+| `grafana_ini.metrics.enabled` | true | Enable metrics |
+| `grafana_ini.metrics.interval_seconds` | 10 | Interval in seconds for metrics collection |
+| `grafana_ini.metrics.disable_total_stats` | false | Disable total stats metrics |
+| `grafana_ini.metrics.total_stats_collector_interval_seconds` | 1800 | Interval in seconds for total stats collector |
+| `grafana_ini.metrics.basic_auth_username` | "" | Basic auth username for metrics endpoints |
+| `grafana_ini.metrics.basic_auth_password` | "" | Basic auth password for metrics endpoints |
 
 Data source example:
 

--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -103,6 +103,13 @@ grafana_ini_default:
   #  basic:
   #    enabled: true
 
+  metrics:
+    enabled: true
+    interval_seconds: 10
+    disable_total_stats: false
+    total_stats_collector_interval_seconds: 1800
+    basic_auth_username: ""
+    basic_auth_password: ""
 
 grafana_api_url: "{{ grafana_ini.server.root_url }}"
 

--- a/roles/grafana/molecule/alternative/tests/test_alternative.py
+++ b/roles/grafana/molecule/alternative/tests/test_alternative.py
@@ -50,3 +50,14 @@ def test_socket(host):
 def test_custom_auth_option(host):
     f = host.file("/etc/grafana/grafana.ini")
     assert f.contains("login_maximum_inactive_lifetime_days = 42")
+
+
+def test_metrics_settings(host):
+    f = host.file("/etc/grafana/grafana.ini")
+    assert f.contains("[metrics]")
+    assert f.contains("enabled = true")
+    assert f.contains("interval_seconds = 10")
+    assert f.contains("disable_total_stats = false")
+    assert f.contains("total_stats_collector_interval_seconds = 1800")
+    assert f.contains("basic_auth_username = ")
+    assert f.contains("basic_auth_password = ")

--- a/roles/grafana/molecule/default/tests/test_default.py
+++ b/roles/grafana/molecule/default/tests/test_default.py
@@ -48,3 +48,14 @@ def test_yum_repo(host):
     if host.system_info.distribution in ['centos', 'redhat', 'fedora']:
         f = host.file("/etc/yum.repos.d/grafana.repo")
         assert f.exists
+
+
+def test_metrics_settings(host):
+    f = host.file("/etc/grafana/grafana.ini")
+    assert f.contains("[metrics]")
+    assert f.contains("enabled = true")
+    assert f.contains("interval_seconds = 10")
+    assert f.contains("disable_total_stats = false")
+    assert f.contains("total_stats_collector_interval_seconds = 1800")
+    assert f.contains("basic_auth_username = ")
+    assert f.contains("basic_auth_password = ")

--- a/roles/grafana/tasks/dashboards.yml
+++ b/roles/grafana/tasks/dashboards.yml
@@ -7,6 +7,7 @@
     state: directory
   register: __tmp_dashboards
   changed_when: false
+  check_mode: false
 
 - name: "Download grafana.net dashboards"
   become: false

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -2,6 +2,8 @@
 - name: Inherit default vars
   ansible.builtin.set_fact:
     grafana_ini: "{{ grafana_ini_default | ansible.builtin.combine(grafana_ini, recursive=true) }}"
+  tags:
+    - always
 - name: "Gather variables for each operating system"
   ansible.builtin.include_vars: "{{ distrovars }}"
   vars:

--- a/roles/opentelemetry_collector/README.md
+++ b/roles/opentelemetry_collector/README.md
@@ -24,6 +24,7 @@ Available variables with their default values are listed below (`defaults/main.y
 | `otel_collector_config_file` | The main configuration file name for the OpenTelemetry Collector. | `"config.yaml"` |
 | `otel_collector_service_user` | The system user under which the OpenTelemetry Collector service will run. | `"otel"` |
 | `otel_collector_service_group` | The system group under which the OpenTelemetry Collector service will run. | `"otel"` |
+| `otel_collector_service_statedirectory` | The directory systemd should create under `/var/lib`. | `"otel-collector"` |
 | `otel_collector_receivers` | Receivers configuration for the OpenTelemetry Collector. | `""` |
 | `otel_collector_exporters` | Exporters configuration for the OpenTelemetry Collector. | `""` |
 | `otel_collector_processors` | Processors configuration for the OpenTelemetry Collector. | `""` |

--- a/roles/opentelemetry_collector/defaults/main.yml
+++ b/roles/opentelemetry_collector/defaults/main.yml
@@ -20,6 +20,7 @@ otel_collector_config_dir: "/etc/otel-collector"
 otel_collector_config_file: "config.yaml"
 otel_collector_service_user: "otel"
 otel_collector_service_group: "otel"
+otel_collector_service_statedirectory: "otel-collector"
 
 otel_collector_receivers: ""
 otel_collector_exporters: ""

--- a/roles/opentelemetry_collector/molecule/default/tests/test_default.py
+++ b/roles/opentelemetry_collector/molecule/default/tests/test_default.py
@@ -11,9 +11,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_directories(host):
-    dirs = [
-        "/etc/otel-collector",
-    ]
+    dirs = ["/etc/otel-collector", "/var/lib/otel-collector"]
     files = ["/etc/otel-collector/config.yaml"]
     for directory in dirs:
         d = host.file(directory)

--- a/roles/opentelemetry_collector/templates/otel_collector.service.j2
+++ b/roles/opentelemetry_collector/templates/otel_collector.service.j2
@@ -8,6 +8,7 @@ ExecStart={{ otel_collector_installation_dir }}/{{ otel_collector_executable }} 
 User={{ otel_collector_service_user }}
 Group={{ otel_collector_service_group }}
 Restart=on-failure
+StateDirectory={{ otel_collector_service_statedirectory }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
feat(grafana): Add ability to enable Metrics in Grafana role.

* Add default variables for the `[metrics]` section in `roles/grafana/defaults/main.yml`.
* Add documentation for the new metrics settings in `roles/grafana/README.md`.
* Add tests to verify the new metrics settings in `roles/grafana/molecule/alternative/tests/test_alternative.py` and `roles/grafana/molecule/default/tests/test_default.py`.

